### PR TITLE
Added TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The `children` contents is what will be rendered into the new popup window. In t
  | `onUnload` | `Function` | `undefined`   | A function to be triggered before the new window unload. |
  | `onBlock`  | `Function` | `undefined`   | A function to be triggered when the new window could not be opened. |
  | `center`   | `String`   | `parent`      | Indicate how to center the new window. Valid values are: `parent` or `screen`. `parent` will center the new window according to its _parent_ window. `screen` will center the new window according to the _screen_. |
+ | `copyStyles`  | `Boolean` | `true`   | If specified, copy styles from parent window's document. |
 
 ## Tests
 

--- a/src/NewWindow.d.ts
+++ b/src/NewWindow.d.ts
@@ -1,0 +1,72 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+/**
+ * Base features common to all window features.
+ * 
+ * @remarks These will be concatenated into a string for window.open.
+ */
+export interface IWindowFeatures {
+    height: number
+    width: number
+    [i: string]: boolean | number | string
+}
+
+/**
+ * Props for opening a new window.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/open
+ */
+declare export interface INewWindowProps {
+    /**
+     * The URL to open, if specified any children will be overriden.
+     */
+    url?: string
+
+    /**
+     * The name of the window.
+     */
+    name?: string
+
+    /**
+     * The title of the new window document.
+     */
+    title?: string
+
+    /**
+     * The set of window features.
+     */
+    features?: IWindowFeatures
+
+    /**
+     * A function to be triggered before the new window unload.
+     */
+    onBlock?: IOnBlock | null
+
+    /**
+     * A function to be triggered when the new window could not be opened.
+     */
+    onUnload?: IOnUnload | null
+
+    /**
+     * Indicate how to center the new window.
+     */
+    center?: 'parent' | 'screen'
+
+    /**
+     * If specified, copy styles from parent window's document.
+     */
+    copyStyles?: boolean
+}
+
+declare export default class NewWindow extends React.PureComponent {
+    private readonly container: HTMLDivElement
+    private window: Window | null
+    private windowCheckerInterval: number | null
+    private released: boolean
+
+    /**
+     * Release the new window and anything that was bound to it.
+     */
+    public release(): void
+}


### PR DESCRIPTION
Fixes #2.

I noticed the `copyStyles` prop is missing in README.md, so added it in to match the TS typings.