### PR TITLE
Don't render until target is ready inside target window.

### DIFF
--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -39,19 +39,28 @@ class NewWindow extends React.PureComponent {
     this.window = null
     this.windowCheckerInterval = null
     this.released = false
+    this.state = {
+      mounted: false
+    };
   }
 
   /**
    * Render the NewWindow component.
    */
   render() {
+    if (!this.state.mounted) return null;
     return ReactDOM.createPortal(this.props.children, this.container)
+  }
+
+  componentDidMount() {
+    this.openChild();
+    this.setState({mounted: true});
   }
 
   /**
    * Create the new window when NewWindow component mount.
    */
-  componentDidMount() {
+  openChild() {
     const { url, title, name, features, onBlock, center } = this.props
 
     // Prepare position of the new window to be centered against the 'parent' window or 'screen'.

--- a/stories/TextBox.story.js
+++ b/stories/TextBox.story.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import NewWindow from '../src/NewWindow'
+import Button from './components/Button'
+import Container from './components/Container'
+
+class TextBoxStory extends React.PureComponent {
+
+  state = {
+    opened: false,
+    text: 'Hi',
+  }
+
+  onInput = (e) => {
+    this.setState({text: e.target.value});
+  }
+
+  render() {
+    const { opened, text } = this.state
+    const now = new Date()
+    return (
+      <Container>
+        <h2>React TextBox</h2>
+        <h3>Example</h3>
+        <p>
+          Text: <code>{text}</code>
+        </p>
+        <Button onClick={ () => this.toggleOpened() }>
+          { opened ? 'Close the opened window' : 'Open a new window' }
+        </Button>
+        { opened &&
+          <NewWindow
+            onUnload={ () => this.newWindowUnloaded() }
+            features={ { left: 200, top: 200, width: 400, height: 400 } }
+          >
+            <h5>Here is a textbox. Type something in it and see it mirror to the parent.</h5>
+            <input type="text" value={text} onChange={this.onInput} />
+          </NewWindow>
+        }
+      </Container>
+    )
+  }
+
+  toggleOpened() {
+    action(this.state.opened ? 'Closing the window' : 'Opening the window')()
+    this.setState({ opened: !this.state.opened })
+  }
+
+  newWindowUnloaded() {
+    action('Window unloaded')()
+    this.setState({ opened: false })
+  }
+}
+
+export default TextBoxStory

--- a/stories/index.js
+++ b/stories/index.js
@@ -5,9 +5,11 @@ import DefaultStory from './Default.story'
 import UrlPropStory from './UrlProp.story'
 import TitlePropStory from './TitleProp.story'
 import FeaturesPropStory from './FeaturesProp.story'
+import TextBoxStory from './TextBox.story'
 
 storiesOf('React New Window', module)
   .add('example', () => <DefaultStory /> )
   .add(' - prop: url', () => <UrlPropStory /> )
   .add(' - prop: title', () => <TitlePropStory /> )
   .add(' - prop: features', () => <FeaturesPropStory /> )
+  .add(' - prop: text box', () => <TextBoxStory /> )


### PR DESCRIPTION
This prevents issues with key handlers in <input> and <textarea> elements. It
appears that React sets up a number of event proxies on mount, and if the
element is first mounted in one document then translocated to another,
these proxies don't follow. So we resist mounting at all until the
child document is ready.

Added a story mirroring text input to illustrate this. It will
fail on the old version.