### PR TITLE
Make package.json `main` point to UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "open",
     "popup"
   ],
-  "main": "src/react-new-window.js",
+  "main": "umd/react-new-window.js",
   "module": "es/react-new-window.js",
   "browser": "umd/react-new-window.js",
   "repository": "git@github.com:rmariuzzo/react-new-window.git",


### PR DESCRIPTION
`src/react-new-window.js` doesn't exist. We could use
`src/NewWindow.js`, but users would still have to compile it.