### PR TITLE
Added missing "types" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "es",
     "umd"
   ],
+  "types": "./src/NewWindow.d.ts",
   "dependencies": {
     "prop-types": "^15.6.1"
   },


### PR DESCRIPTION
TypeScript won't pick up on typings unless that field is there.