### PR TITLE
do never convert <link> to <style>

### DIFF
--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -186,46 +186,49 @@ NewWindow.propTypes = {
 
 function copyStyles(source, target) {
   Array.from(source.styleSheets).forEach(styleSheet => {
-    // For <style> elements
-    let rules
-    try {
-      rules = styleSheet.cssRules
-    } catch (err) {
-      console.error(err)
-    }
-    if (rules) {
-      const newStyleEl = source.createElement('style')
-
-      // Write the text of each rule into the body of the style element
-      Array.from(styleSheet.cssRules).forEach(cssRule => {
-        const { cssText, type } = cssRule
-        let returnText = cssText
-        // Check if the cssRule type is CSSImportRule (3) or CSSFontFaceRule (5) to handle local imports on a about:blank page
-        // '/custom.css' turns to 'http://my-site.com/custom.css'
-        if ([3, 5].includes(type)) {
-          returnText = cssText
-            .split('url(')
-            .map(line => {
-              if (line[1] === '/') {
-                return `${line.slice(0, 1)}${
-                  window.location.origin
-                }${line.slice(1)}`
-              }
-              return line
-            })
-            .join('url(')
-        }
-        newStyleEl.appendChild(source.createTextNode(returnText))
-      })
-
-      target.head.appendChild(newStyleEl)
-    } else if (styleSheet.href) {
+    if (styleSheet.href) {
       // for <link> elements loading CSS from a URL
       const newLinkEl = source.createElement('link')
 
       newLinkEl.rel = 'stylesheet'
       newLinkEl.href = styleSheet.href
       target.head.appendChild(newLinkEl)
+    } else {
+      // For <style> elements
+      let rules
+      try {
+        rules = styleSheet.cssRules
+      } catch (err) {
+        console.error(err)
+      }
+
+      if (rules) {
+        const newStyleEl = source.createElement('style')
+
+        // Write the text of each rule into the body of the style element
+        Array.from(styleSheet.cssRules).forEach(cssRule => {
+          const { cssText, type } = cssRule
+          let returnText = cssText
+          // Check if the cssRule type is CSSImportRule (3) or CSSFontFaceRule (5) to handle local imports on a about:blank page
+          // '/custom.css' turns to 'http://my-site.com/custom.css'
+          if ([3, 5].includes(type)) {
+            returnText = cssText
+              .split('url(')
+              .map(line => {
+                if (line[1] === '/') {
+                  return `${line.slice(0, 1)}${
+                    window.location.origin
+                  }${line.slice(1)}`
+                }
+                return line
+              })
+              .join('url(')
+          }
+          newStyleEl.appendChild(source.createTextNode(returnText))
+        })
+
+        target.head.appendChild(newStyleEl)
+      }
     }
   })
 }


### PR DESCRIPTION
I don't expect this to get merged in its current form as **it is a breaking change**. However, we need a solution (maybe a config?).

Right now a `<link>` element that is on the same-origin or that is configured with `crossorigin` is always converted to `<style>` (because `.cssRules` can be accessed, which is otherwise prevented by the SOP). This breaks our Content-Security-Policy because it forbids inline styles. This PR fixes this by always injecting a `<link>` if the source is also a `<link>`.

However, this breaks current uses that rely on the current behavior to rewrite import and font-face rules in `<link>` by making the paths absolute.

Thoughts?