### PR TITLE
Fix creating new window does not work in Edge

### DIFF
--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -33,7 +33,7 @@ class NewWindow extends React.PureComponent {
    */
   constructor(props) {
     super(props)
-    this.container = document.createElement('div')
+    this.container = null
     this.window = null
     this.windowCheckerInterval = null
     this.released = false
@@ -97,7 +97,7 @@ class NewWindow extends React.PureComponent {
 
     // Open a new window.
     this.window = window.open(url, name, toWindowFeatures(features))
-
+    this.container = this.window.document.createElement('div')
     // When a new window use content from a cross-origin there's no way we can attach event
     // to it. Therefore, we need to detect in a interval when the new window was destroyed
     // or was closed.
@@ -194,7 +194,7 @@ function copyStyles(source, target) {
       console.error(err)
     }
     if (rules) {
-      const newStyleEl = source.createElement('style')
+      const newStyleEl = target.createElement('style')
 
       // Write the text of each rule into the body of the style element
       Array.from(styleSheet.cssRules).forEach(cssRule => {
@@ -215,13 +215,13 @@ function copyStyles(source, target) {
             })
             .join('url(')
         }
-        newStyleEl.appendChild(source.createTextNode(returnText))
+        newStyleEl.appendChild(target.createTextNode(returnText))
       })
 
       target.head.appendChild(newStyleEl)
     } else if (styleSheet.href) {
       // for <link> elements loading CSS from a URL
-      const newLinkEl = source.createElement('link')
+      const newLinkEl = target.createElement('link')
 
       newLinkEl.rel = 'stylesheet'
       newLinkEl.href = styleSheet.href


### PR DESCRIPTION
This attempts to resolve issues with Edge and IE.  With these changes popup works fine except...

... In Edge copying the styles seems to be very slow. It'll take several seconds to copy the parent styles in Edge while Chrome and Firefox are much faster (perceived, I have not timed it explicitly).

... In IE the styles are not copied over as Array.from is not available in IE. I believe the consumer will need to include a polyfill for this to work correctly.

