### PR TITLE
Include props in NewWindow type definitions

### DIFF
--- a/src/NewWindow.d.ts
+++ b/src/NewWindow.d.ts
@@ -59,7 +59,7 @@ declare export interface INewWindowProps {
     copyStyles?: boolean
 }
 
-declare export default class NewWindow extends React.PureComponent {
+declare export default class NewWindow extends React.PureComponent<INewWindowProps> {
     private readonly container: HTMLDivElement
     private window: Window | null
     private windowCheckerInterval: number | null


### PR DESCRIPTION
Currently, props such as url do not exist on the NewWindow component exported by the library.

For example

```
import React from 'react'
import NewWindow from "react-new-window"

const A = () => <NewWindow url="https://www.google.com" />
```

Gives a type error

```
Type '{ url: string; }' is not assignable to type
'IntrinsicAttributes & IntrinsicClassAttributes<NewWindow> & Readonly<{ children?: ReactNode; }> & Readonly<{}>'.
  Property 'url' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<NewWindow> & Readonly<{ children?: ReactNode; }> & Readonly<{}>'.
```

This change modifies the definitions such that a `PureComponent` with props `INewWindowProps` is exported
