### PR TITLE
Disable default centering (#47) and improve typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `children` contents is what will be rendered into the new popup window. In t
  | `features` | `Object`   | `{}`          | The set of window features ([more details on `windowFeatures`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)). |
  | `onUnload` | `Function` | `undefined`   | A function to be triggered before the new window unload. |
  | `onBlock`  | `Function` | `undefined`   | A function to be triggered when the new window could not be opened. |
- | `center`   | `String`   | `parent`      | Indicate how to center the new window. Valid values are: `parent` or `screen`. `parent` will center the new window according to its _parent_ window. `screen` will center the new window according to the _screen_. |
+ | `center`   | `String`   | `undefined`      | Indicate how to center the new window. Valid values are: `parent` or `screen`. `parent` will center the new window according to its _parent_ window. `screen` will center the new window according to the _screen_. |
  | `copyStyles`  | `Boolean` | `true`   | If specified, copy styles from parent window's document. |
 
 ## Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -6645,8 +6645,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6806,7 +6805,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6825,7 +6823,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6919,7 +6916,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7005,8 +7001,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7042,7 +7037,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7106,14 +7100,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -24,7 +24,6 @@ class NewWindow extends React.PureComponent {
     onBlock: null,
     onOpen: null,
     onUnload: null,
-    center: 'parent',
     copyStyles: true
   }
 
@@ -63,37 +62,40 @@ class NewWindow extends React.PureComponent {
     const { url, title, name, features, onBlock, onOpen, center } = this.props
 
     // Prepare position of the new window to be centered against the 'parent' window or 'screen'.
-    if (
-      typeof center === 'string' &&
-      (features.width === undefined || features.height === undefined)
-    ) {
-      console.warn(
-        'width and height window features must be present when a center prop is provided'
-      )
-    } else if (center === 'parent') {
-      features.left =
-        window.top.outerWidth / 2 + window.top.screenX - features.width / 2
-      features.top =
-        window.top.outerHeight / 2 + window.top.screenY - features.height / 2
-    } else if (center === 'screen') {
-      const screenLeft =
-        window.screenLeft !== undefined ? window.screenLeft : window.screen.left
-      const screenTop =
-        window.screenTop !== undefined ? window.screenTop : window.screen.top
+    if (typeof center === 'string') {
+      if (features.width == null || features.height == null) {
+        console.warn(
+          'react-new-window: "width" and "height" window features must be present when a center prop is provided.'
+        )
+      } else if (center === 'parent') {
+        features.left =
+          window.top.outerWidth / 2 + window.top.screenX - features.width / 2
+        features.top =
+          window.top.outerHeight / 2 + window.top.screenY - features.height / 2
+      } else if (center === 'screen') {
+        const screenLeft =
+          window.screenLeft != null ? window.screenLeft : window.screen.left
+        const screenTop =
+          window.screenTop != null ? window.screenTop : window.screen.top
 
-      const width = window.innerWidth
-        ? window.innerWidth
-        : document.documentElement.clientWidth
-        ? document.documentElement.clientWidth
-        : window.screen.width
-      const height = window.innerHeight
-        ? window.innerHeight
-        : document.documentElement.clientHeight
-        ? document.documentElement.clientHeight
-        : window.screen.height
+        const width = window.innerWidth
+          ? window.innerWidth
+          : document.documentElement.clientWidth
+          ? document.documentElement.clientWidth
+          : window.screen.width
+        const height = window.innerHeight
+          ? window.innerHeight
+          : document.documentElement.clientHeight
+          ? document.documentElement.clientHeight
+          : window.screen.height
 
-      features.left = width / 2 - features.width / 2 + screenLeft
-      features.top = height / 2 - features.height / 2 + screenTop
+        features.left = width / 2 - features.width / 2 + screenLeft
+        features.top = height / 2 - features.height / 2 + screenTop
+      } else {
+        console.warn(
+          'react-new-window: Invalid `center` string provided. Only these strings are permitted: "parent", "screen".'
+        )
+      }
     }
 
     // Open a new window.

--- a/stories/features-prop.stories.js
+++ b/stories/features-prop.stories.js
@@ -97,7 +97,6 @@ class FeaturesPropStory extends React.PureComponent {
         </Button>
         {opened && (
           <NewWindow
-            center={false}
             features={features}
             onUnload={() => this.newWindowUnloaded()}
           >

--- a/stories/position-centered-to-parent.stories.js
+++ b/stories/position-centered-to-parent.stories.js
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react'
 
 const stories = storiesOf('react-new-window', module)
 
-class DefaultStory extends React.PureComponent {
+class CenteredToParentStory extends React.PureComponent {
   state = {
     opened: false,
     count: 0
@@ -28,7 +28,7 @@ class DefaultStory extends React.PureComponent {
     return (
       <Container>
         <h2>React New Window</h2>
-        <h3>Example</h3>
+        <h3>prop: center: "parent"</h3>
         <h4>Counting {count}...</h4>
         <Button onClick={() => this.toggleOpened()}>
           {opened ? 'Close the opened window' : 'Open a new window'}
@@ -36,7 +36,8 @@ class DefaultStory extends React.PureComponent {
         {opened && (
           <NewWindow
             onUnload={() => this.newWindowUnloaded()}
-            features={{ width: 400, height: 400 }}
+            center="parent"
+            features={{ left: 200, top: 200, width: 400, height: 400 }}
           >
             <h2>Hi 👋</h2>
             <h4>Counting here as well {count}...</h4>
@@ -58,4 +59,4 @@ class DefaultStory extends React.PureComponent {
   }
 }
 
-stories.add('Default', () => <DefaultStory />)
+stories.add('Position: Centered To Parent', () => <CenteredToParentStory />)

--- a/stories/position-centered-to-screen.stories.js
+++ b/stories/position-centered-to-screen.stories.js
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react'
 
 const stories = storiesOf('react-new-window', module)
 
-class DefaultStory extends React.PureComponent {
+class CenteredToScreenStory extends React.PureComponent {
   state = {
     opened: false,
     count: 0
@@ -28,7 +28,7 @@ class DefaultStory extends React.PureComponent {
     return (
       <Container>
         <h2>React New Window</h2>
-        <h3>Example</h3>
+        <h3>prop: center: "screen"</h3>
         <h4>Counting {count}...</h4>
         <Button onClick={() => this.toggleOpened()}>
           {opened ? 'Close the opened window' : 'Open a new window'}
@@ -36,7 +36,8 @@ class DefaultStory extends React.PureComponent {
         {opened && (
           <NewWindow
             onUnload={() => this.newWindowUnloaded()}
-            features={{ width: 400, height: 400 }}
+            center="screen"
+            features={{ left: 200, top: 200, width: 400, height: 400 }}
           >
             <h2>Hi 👋</h2>
             <h4>Counting here as well {count}...</h4>
@@ -58,4 +59,4 @@ class DefaultStory extends React.PureComponent {
   }
 }
 
-stories.add('Default', () => <DefaultStory />)
+stories.add('Position: Centered To Screen', () => <CenteredToScreenStory />)

--- a/types/NewWindow.d.ts
+++ b/types/NewWindow.d.ts
@@ -13,6 +13,14 @@ declare module 'react-new-window' {
   export interface IWindowFeatures {
     height: number
     width: number
+    left: number
+    top: number
+    menubar: boolean
+    toolbar: boolean
+    scrollbars: boolean
+    location: boolean
+    status: boolean
+    resizable: boolean
     [i: string]: boolean | number | string
   }
 
@@ -40,7 +48,7 @@ declare module 'react-new-window' {
     /**
      * The set of window features.
      */
-    features?: IWindowFeatures
+    features?: Partial<IWindowFeatures>
 
     /**
      * A function to be triggered before the new window unload.


### PR DESCRIPTION
So, learning that #47 is easily overcome with `center={false}` (I really, really thought that `react-new-window` is hardcoded to use some kind of centering), I wanted to improve the quality of life a bit by making center `undefined` at the start.

Also, I've added additional attribs to the `IWindowFeatures` interface so that it's clear what attributes go to the `features` prop. Referenced from [`react-popout-component`](https://github.com/microsoft/react-popout-component/blob/master/src/WindowFeaturesOptions.ts), figured the `interface` could be useful since that library hasn't seen new merged commits in almost a year...

Feel free to roast my commit if it means writing even better code. :)