### PR TITLE
Fix onUnload triggers as soon as window is opened on Safari #57

### DIFF
--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -123,7 +123,7 @@ class NewWindow extends React.PureComponent {
       }
 
       // Release anything bound to this component before the new window unload.
-      this.window.addEventListener('beforeunload', () => this.release())
+      this.window.addEventListener('ononload', () => this.release())
     } else {
       // Handle error on opening of new window.
       if (typeof onBlock === 'function') {


### PR DESCRIPTION
Fix onUnload triggers as soon as window is opened on Safari #57