### PR TITLE
Add 'closeWithParent' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The `children` contents is what will be rendered into the new popup window. In t
  | `onBlock`  | `Function` | `undefined`   | A function to be triggered when the new window could not be opened. |
  | `center`   | `String`   | `parent`      | Indicate how to center the new window. Valid values are: `parent` or `screen`. `parent` will center the new window according to its _parent_ window. `screen` will center the new window according to the _screen_. |
  | `copyStyles`  | `Boolean` | `true`   | If specified, copy styles from parent window's document. |
+ | `closeWithParent`  | `Boolean` | `false`   | Close the child window when the parent is closed. |
 
 ## Tests
 

--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -25,7 +25,8 @@ class NewWindow extends React.PureComponent {
     onOpen: null,
     onUnload: null,
     center: 'parent',
-    copyStyles: true
+    copyStyles: true,
+    closeWithParent: false
   }
 
   /**
@@ -124,6 +125,10 @@ class NewWindow extends React.PureComponent {
 
       // Release anything bound to this component before the new window unload.
       this.window.addEventListener('beforeunload', () => this.release())
+
+      if (this.props.closeWithParent) {
+        window.addEventListener('unload', () => this.window.close())
+      }
     } else {
       // Handle error on opening of new window.
       if (typeof onBlock === 'function') {
@@ -140,6 +145,10 @@ class NewWindow extends React.PureComponent {
   componentWillUnmount() {
     if (this.window) {
       this.window.close()
+
+      if (this.props.closeWithParent) {
+        window.removeEventListener('unload', () => this.window.close())
+      }
     }
   }
 
@@ -175,7 +184,8 @@ NewWindow.propTypes = {
   onBlock: PropTypes.func,
   onOpen: PropTypes.func,
   center: PropTypes.oneOf(['parent', 'screen']),
-  copyStyles: PropTypes.bool
+  copyStyles: PropTypes.bool,
+  closeWithParent: PropTypes.bool
 }
 
 /**

--- a/types/NewWindow.d.ts
+++ b/types/NewWindow.d.ts
@@ -66,6 +66,11 @@ declare module 'react-new-window' {
      * If specified, copy styles from parent window's document.
      */
     copyStyles?: boolean
+
+    /**
+    * Close the child window when the parent is closed.
+    * */
+    closeWithParent?: boolean
   }
 
   export default class NewWindow extends React.PureComponent<INewWindowProps> {


### PR DESCRIPTION
This PR proposes to add a boolean prop, 'closeWithParent', that would allow for the automatic closing of child windows when the parent window closes, or reloads.

It would address the issue raised here: https://github.com/rmariuzzo/react-new-window/issues/50

