### PR TITLE
added typescript definition for closeOnUnmount

### DIFF
--- a/types/NewWindow.d.ts
+++ b/types/NewWindow.d.ts
@@ -66,6 +66,11 @@ declare module 'react-new-window' {
      * If specified, copy styles from parent window's document.
      */
     copyStyles?: boolean
+    
+    /**
+     * If specified, close the new window on unmount.
+     */
+    closeOnUnmount?: boolean
   }
 
   export default class NewWindow extends React.PureComponent<INewWindowProps> {


### PR DESCRIPTION
Fix for "Property 'closeOnUnmount' does not exist on type" error when attempting to use the closeOnUnmount prop w/ TypeScript