### PR TITLE
Include children in NewWindow type definition

### DIFF
--- a/types/NewWindow.d.ts
+++ b/types/NewWindow.d.ts
@@ -23,6 +23,11 @@ declare module 'react-new-window' {
    */
   export interface INewWindowProps {
     /**
+     * Children to render in the new window.
+     */
+    children?: React.ReactNode
+
+    /**
      * The URL to open, if specified any children will be overriden.
      */
     url?: string


### PR DESCRIPTION
Fixes https://github.com/rmariuzzo/react-new-window/issues/118

This PR simply adds ``children?: React.ReactNode`` to NewWindow's type definition, which seems to be enough.