### PR TITLE
Fix type error in IWindowFeatures (#145)

### DIFF
--- a/types/NewWindow.d.ts
+++ b/types/NewWindow.d.ts
@@ -13,7 +13,7 @@ declare module 'react-new-window' {
   export interface IWindowFeatures {
     height?: number
     width?: number
-    [i: string]: boolean | number | string
+    [i: string]: boolean | number | string | undefined
   }
 
   /**


### PR DESCRIPTION
A TypeScript index signature for an object type must be compatible with all properties of the object.

https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures