### PR TITLE
fix: remove unnecessary code which prevents onBlock to be invoked

### DIFF
--- a/src/NewWindow.js
+++ b/src/NewWindow.js
@@ -102,7 +102,7 @@ class NewWindow extends React.PureComponent {
 
     // Open a new window.
     this.window = window.open(url, name, toWindowFeatures(features))
-    this.container = this.window.document.createElement('div')
+
     // When a new window use content from a cross-origin there's no way we can attach event
     // to it. Therefore, we need to detect in a interval when the new window was destroyed
     // or was closed.


### PR DESCRIPTION
Fix for the issue #152 

The deleted line seems to be unnecessary and it will fail when the browser is blocking the popup/tab opening.
This will result in the `onBlock` callback to never be called